### PR TITLE
Fixed struct init via memset(), throws error on new compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ Related projects:
 History
 -------
 * 0.5.4 (2021-01-XX) [not yet published] Minor fixes:
-  * `ustd::Console` and `ustd::SerialConsole` do now hnour the USTD_FEATURE_xxx defines.
+  * `ustd::Console` and `ustd::SerialConsole` do now honour the USTD_FEATURE_xxx defines.
+  * Safe struct inits (no memset())
+  * Support for new platforms defined in ustd
 * 0.5.3 (2021-01-22) `UST_FEATURE_MEM` defines used (requires `ustd` version 0.4.1 or higher), ATtiny T_TASK limited to static functions.
 * 0.5.2 (2021-01-20) `library.properties` project name repaired, to allow Arduino automatic update.
 * 0.5.1 (2021-01-19)

--- a/console.h
+++ b/console.h
@@ -141,8 +141,7 @@ class Console {
          * @return commandHandle on success (needed for unextend), or -1
          * on error.
          */
-        T_COMMAND cmd;
-        memset(&cmd, 0, sizeof(cmd));
+        T_COMMAND cmd {};
         cmd.id = ++commandHandle;
         cmd.fn = handler;
         cmd.command = (char *)malloc(command.length() + 1);

--- a/console.h
+++ b/console.h
@@ -141,7 +141,7 @@ class Console {
          * @return commandHandle on success (needed for unextend), or -1
          * on error.
          */
-        T_COMMAND cmd {};
+        T_COMMAND cmd = {};
         cmd.id = ++commandHandle;
         cmd.fn = handler;
         cmd.command = (char *)malloc(command.length() + 1);


### PR DESCRIPTION
Memsetting structs to zero in C++ is considered increasingly illegal with modern compilers:
* throws lots of warnings on ARM
* stops with Error on RISC-V
