### PR TITLE
Hotfix/arduinonames

### DIFF
--- a/Examples/console/src/mu_console.cpp
+++ b/Examples/console/src/mu_console.cpp
@@ -1,7 +1,7 @@
 //#define USE_SERIAL_DBG 1
 
 // Make sure to use a platform define before following includes
-#include "platform.h"
+#include "ustd_platform.h"
 #include "scheduler.h"
 #include "heartbeat.h"
 #include "doctor.h"

--- a/Examples/mac-linux/muwerk-test.cpp
+++ b/Examples/mac-linux/muwerk-test.cpp
@@ -7,11 +7,11 @@
 
 #define USE_SERIAL_DBG 1
 
-#include "platform.h"
+#include "ustd_platform.h"
 
-#include "array.h"
-#include "map.h"
-#include "queue.h"
+#include "ustd_array.h"
+#include "ustd_map.h"
+#include "ustd_queue.h"
 
 #include "scheduler.h"
 

--- a/Examples/minimal/src/mu_minimal.cpp
+++ b/Examples/minimal/src/mu_minimal.cpp
@@ -1,7 +1,7 @@
 #define USE_SERIAL_DBG 1
 
 // Make sure to use a platform define before following includes
-#include "platform.h"
+#include "ustd_platform.h"
 #include "scheduler.h"
 #include "heartbeat.h"
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Related projects:
 
 History
 -------
+* 0.6.0 (2021-01-30) Breaking change for ustd library include: ustd include-files have now `ustd_` prefix.
 * CI (2021-01-28 All supported platforms are build-checked automatically with Github actions.
 * 0.5.4 (2021-01-28) Minor fixes:
   * `ustd::Console` and `ustd::SerialConsole` do now honour the USTD_FEATURE_xxx defines.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ Related projects:
 
 History
 -------
-* 0.6.0 (2021-01-30) Breaking change for ustd library include: ustd include-files have now `ustd_` prefix.
+* 0.6.0 (2021-01-30) **Breaking change** for ustd library include: ustd include-files have now `ustd_` prefix to prevent name-clashes with various platform-sdks. [queue.h clashed with ESP8266-Wifi, platform.h clashed with
+RISC-V SDK, hence new names `ustd_queue.h` and `ustd_platform.h` etc.]
 * CI (2021-01-28 All supported platforms are build-checked automatically with Github actions.
 * 0.5.4 (2021-01-28) Minor fixes:
   * `ustd::Console` and `ustd::SerialConsole` do now honour the USTD_FEATURE_xxx defines.

--- a/console.h
+++ b/console.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include "platform.h"
-#include "array.h"
+#include "ustd_platform.h"
+#include "ustd_array.h"
 #include "muwerk.h"
 #include "scheduler.h"
 

--- a/filesystem.h
+++ b/filesystem.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "platform.h"
+#include "ustd_platform.h"
 
 #ifdef __ESP32__
 namespace fs {

--- a/heartbeat.h
+++ b/heartbeat.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "platform.h"
+#include "ustd_platform.h"
 #include "muwerk.h"
 
 namespace ustd {

--- a/jsonfile.h
+++ b/jsonfile.h
@@ -2,9 +2,9 @@
 
 #pragma once
 
-#include "platform.h"
-#include "array.h"
-#include "map.h"
+#include "ustd_platform.h"
+#include "ustd_array.h"
+#include "ustd_map.h"
 #include "muwerk.h"
 #include "filesystem.h"
 

--- a/library.json
+++ b/library.json
@@ -23,7 +23,7 @@
         "authors": "Dominik Schlösser, Leo Moll",
         "frameworks": "arduino"
     },
-    "version": "0.5.4",
+    "version": "0.6.0",
     "frameworks": "arduino",
     "platforms": "*"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Muwerk scheduler library
-version=0.5.4
+version=0.6.0
 author=Dominik Schlösser, Leo Moll
 maintainer=Dominik Schlösser, <dsc@dosc.net>
 sentence=cooperative scheduler and mqtt-like communication queues

--- a/muwerk.h
+++ b/muwerk.h
@@ -35,8 +35,8 @@ used by:
 * * <a href="https://github.com/muwerk/munet">munet github repository</a>
 */
 
-#include "platform.h"
-#include "array.h"
+#include "ustd_platform.h"
+#include "ustd_array.h"
 
 //! \brief The muwerk namespace
 namespace ustd {

--- a/scheduler.h
+++ b/scheduler.h
@@ -2,21 +2,15 @@
 
 #pragma once
 
-/*
-#include "../ustd/platform.h"
-#include "../ustd/array.h"
-#include "../ustd/queue.h"
-#include "../ustd/functional.h"
-*/
-#include "platform.h"
-#include "array.h"
-#include "queue.h"
-#include "functional.h"
+#include "ustd_platform.h"
+#include "ustd_array.h"
+#include "ustd_queue.h"
+#include "ustd_functional.h"
 #include "muwerk.h"
 
 #include <stdio.h>
 
-#if defined(__ESP__) || defined(__UNIXOID__)
+#if defined(__ESP__) || defined(__ESP32__) || defined(__UNIXOID__)
 #include <functional>
 #endif
 

--- a/sensors.h
+++ b/sensors.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "platform.h"
+#include "ustd_platform.h"
 
 namespace ustd {
 #define SENSOR_VALUE_INVALID -999999.0

--- a/timeout.h
+++ b/timeout.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "platform.h"
+#include "ustd_platform.h"
 #include "muwerk.h"
 
 namespace ustd {


### PR DESCRIPTION
0.6.0 (2021-01-30) **Breaking change** for ustd library include: 

* ustd include-files have now `ustd_` prefix to prevent name-clashes with various platform-sdks. [queue.h clashed with ESP8266-Wifi, platform.h clashed with RISC-V SDK, hence new names `ustd_queue.h` and `ustd_platform.h` etc.]